### PR TITLE
Perf: Avoid creating heap allocations

### DIFF
--- a/src/controllers/auth_controller.go
+++ b/src/controllers/auth_controller.go
@@ -57,19 +57,20 @@ func (ctx *AuthController) Callback(w http.ResponseWriter, r *http.Request) {
 		Name: provider_user.Name,
 		ImageUrl: provider_user.AvatarURL,
 	}
-	user, _, err := ctx.UserService.FindOrCreate(&check_user)
+	var user types.User
+	_, err = ctx.UserService.FindOrCreate(&check_user, &user)
 	if err != nil {
 		utils.FailResponse(w, "something went wrong")
 		return
 	}
-	token, err := utils.GenerateJWT(ctx.Tokens.JwtKey, user)
+	token, err := utils.GenerateJWT(ctx.Tokens.JwtKey, &user)
 	if err != nil {
 		utils.FailResponse(w, "could not generate token")
 		return
 	}
 	auth := types.Auth{
 		Token: token,
-		User: *user,
+		User: user,
 	}
 	utils.JsonResponse(w, &auth)
 }

--- a/src/controllers/controller.go
+++ b/src/controllers/controller.go
@@ -43,14 +43,15 @@ func (ctx *Controller) UseJwtAuth(next http.Handler) http.Handler {
 			}
 
 			// Get user from id, username, email
-			user, err := user_services.FindByIdAndEmail(claims["id"].(string), claims["email"].(string))
+			var user types.User
+			err = user_services.FindByIdAndEmail(claims["id"].(string), claims["email"].(string), &user)
 			if err != nil {
 				utils.FailResponseUnauthorized(w, AUTH_REQ)
 				return
 			}
 			r = r.WithContext(context.WithValue(r.Context(), types.AuthKey, types.Auth{
 				Token: raw_token,
-				User: *user,
+				User: user,
 			}))
 			// Serve handler with updated request
 			next.ServeHTTP(w, r)

--- a/src/controllers/products_controller.go
+++ b/src/controllers/products_controller.go
@@ -82,7 +82,8 @@ func (ctx *ProductsController) create_product(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	new_product, _, err := ctx.ProductService.CreateOrUpdate(&create_product)
+	var new_product types.Product
+	_, err := ctx.ProductService.CreateOrUpdate(&create_product, &new_product)
 	if err != nil {
 		utils.FailResponse(w, []string{"could not create product", err.Error()})
 		return
@@ -93,8 +94,8 @@ func (ctx *ProductsController) create_product(w http.ResponseWriter, r *http.Req
 func (ctx *ProductsController) find_product(w http.ResponseWriter, r *http.Request) {
 	query_params := mux.Vars(r)
 	id := query_params["id"]
-	product, err := ctx.ProductService.Find(id)
-	if err != nil {
+	var product types.Product
+	if ctx.ProductService.Find(id, &product) != nil {
 		utils.FailResponse(w, "product not found")
 		return
 	}

--- a/src/services/product_service.go
+++ b/src/services/product_service.go
@@ -19,7 +19,8 @@ func (service *ProductService) Create(create_product *types.CreateProduct) (*typ
 		return nil, err
 	}
 
-	category, _, category_err := service.CategoryService.FindOrCreate(create_product.Category)
+	var category types.Category
+	_, category_err := service.CategoryService.FindOrCreate(create_product.Category, &category)
 	if category_err != nil {
 		return nil, category_err
 	}
@@ -34,7 +35,7 @@ func (service *ProductService) Create(create_product *types.CreateProduct) (*typ
 		OriginalUrl: create_product.OriginalUrl,
 		TotalReviews: create_product.TotalReviews,
 		CategoryId: category.ID,
-		Category: *category,
+		Category: category,
 	}
 	// add website origin
 	parsed_url, err := url.ParseRequestURI(create_product.OriginalUrl)
@@ -102,10 +103,11 @@ func (service *ProductService) CreateOrUpdate(create_product *types.CreateProduc
 		changed = true
 	}
 	if create_product.Category != product.Category.Name {
-		new_category, _, category_err := service.CategoryService.FindOrCreate(create_product.Category)
+		var new_category types.Category
+		_, category_err := service.CategoryService.FindOrCreate(create_product.Category, &new_category)
 		if category_err == nil {
 			product.CategoryId = new_category.ID
-			product.Category = *new_category
+			product.Category = new_category
 			changed = true
 		}
 	}

--- a/src/services/user_service.go
+++ b/src/services/user_service.go
@@ -8,69 +8,56 @@ type UserService struct {
 	*Service
 }
 
-func (service *UserService) FindByEmail(email string) (*types.User, error) {
-	var user types.User
-	err := service.DB.
+func (service *UserService) FindByEmail(email string, user *types.User) error {
+	return service.DB.
 		Table(service.TABLE).
 		Where("email = ?", email).
-		First(&user).
+		First(user).
 		Error
-	return &user, err
 }
 
-func (service *UserService) FindById(id string) (*types.User, error) {
-	var user types.User
-	err := service.DB.
+func (service *UserService) FindById(id string, user *types.User) error {
+	return service.DB.
 		Table(service.TABLE).
 		Where("id = ?", id).
-		First(&user).
+		First(user).
 		Error
-	return &user, err
 }
 
-func (service *UserService) FindByIdAndEmail(id string, email string) (*types.User, error) {
-	var user types.User
-	err := service.DB.
+func (service *UserService) FindByIdAndEmail(id string, email string, user *types.User) error {
+	return service.DB.
 		Table(service.TABLE).
 		Where("id = ? AND email = ?", id, email).
-		First(&user).
+		First(user).
 		Error
-	return &user, err
 }
 
-func (service *UserService) FindByIdOrEmail(id string, email string) (*types.User, error) {
-	var user types.User
-	err := service.DB.
+func (service *UserService) FindByIdOrEmail(id string, email string, user *types.User) error {
+	return service.DB.
 		Table(service.TABLE).
 		Where("id = ? OR email = ?", id, email).
-		First(&user).
+		First(user).
 		Error
-	return &user, err
 }
 
 // finds a user by email or creates one if not found. 
 // boolean value is true if a new user is created, otherwise false
-func (service *UserService) FindOrCreate(create_user *types.CreateUser) (*types.User, bool, error) {
-	user, err := service.FindByEmail(create_user.Email)
-	if err != nil {
-		user, err = service.Create(create_user)
-		if err != nil {
-			return nil, false, err
+func (service *UserService) FindOrCreate(create_user *types.CreateUser, user *types.User) (bool, error) {
+	if err := service.FindByEmail(create_user.Email, user); err != nil {
+		if err = service.Create(create_user, user); err != nil {
+			return false, err
 		}
-		return user, true, nil
+		return true, nil
 	}
-	return user, false, nil
+	return false, nil
 }
 
-func (service *UserService) Create(create_user *types.CreateUser) (*types.User, error) {
-	user := types.User{
-		Name: create_user.Name,
-		Email: create_user.Email,
-		ImageUrl: create_user.ImageUrl,
-	}
-	err := service.DB.
+func (service *UserService) Create(create_user *types.CreateUser, user *types.User) error {
+	user.Name = create_user.Name
+	user.Email = create_user.Email
+	user.ImageUrl = create_user.ImageUrl
+	return service.DB.
 		Table(service.TABLE).
-		Create(&user).
+		Create(user).
 		Error
-	return &user, err
 }

--- a/src/tests/auth_controller_test.go
+++ b/src/tests/auth_controller_test.go
@@ -92,14 +92,15 @@ func TestAuthController(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			user, _, err := user_service.FindOrCreate(&types.CreateUser{
+			var user types.User
+			_, err = user_service.FindOrCreate(&types.CreateUser{
 				Name: "Naruto Uzumaki",
 				Email: "naruto_uzumaki@gmail.com",
-			})
+			}, &user)
 			if err != nil {
 				t.Fatal(err)
 			}
-			jwt, err := utils.GenerateJWT(token, user)
+			jwt, err := utils.GenerateJWT(token, &user)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -123,14 +124,15 @@ func TestAuthController(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				user, _, err := user_service.FindOrCreate(&types.CreateUser{
+				var user types.User
+				_, err = user_service.FindOrCreate(&types.CreateUser{
 					Name: "Non Admin User",
 					Email: "non_admin_user@gmail.com",
-				})
+				}, &user)
 				if err != nil {
 					t.Fatal(err)
 				}
-				jwt, err := utils.GenerateJWT(token, user)
+				jwt, err := utils.GenerateJWT(token, &user)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -153,10 +155,11 @@ func TestAuthController(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				user, _, err := user_service.FindOrCreate(&types.CreateUser{
+				var user types.User
+				_, err = user_service.FindOrCreate(&types.CreateUser{
 					Name: "Admin User",
 					Email: "admin_user@gmail.com",
-				})
+				}, &user)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -166,7 +169,7 @@ func TestAuthController(t *testing.T) {
 					t.Fatal("could not update user admin level")
 				}
 
-				jwt, err := utils.GenerateJWT(token, user)
+				jwt, err := utils.GenerateJWT(token, &user)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/src/tests/category_service_test.go
+++ b/src/tests/category_service_test.go
@@ -21,8 +21,8 @@ func TestCategoryService(t *testing.T) {
 			t.Cleanup(func() {
 				category_service.DB.Exec("delete from categories")
 			})
-			input_created, err := category_service.Create(&input)
-			if err != nil {
+			var input_created types.Category
+			if err := category_service.Create(&input, &input_created); err != nil {
 				t.Fatal(err.Error())
 			}
 			if input_created.Name != input.Name || input_created.Url != input.Url || input_created.Description != input.Description {
@@ -34,8 +34,9 @@ func TestCategoryService(t *testing.T) {
 			input := types.CreateCategory{
 				Name: "",
 			}
-			created, err := category_service.Create(&input)
-			if err == nil || created != nil {
+			var created types.Category
+			err := category_service.Create(&input, &created)
+			if err == nil {
 				t.Fatal(err.Error())
 			}
 		})
@@ -43,13 +44,13 @@ func TestCategoryService(t *testing.T) {
 
 	t.Run("find category", func(t *testing.T) {
 		t.Run("should return created category", func(t *testing.T) {
-			input_created, err := category_service.Create(&input)
-			if err != nil {
+			var input_created types.Category
+			if err := category_service.Create(&input, &input_created); err != nil {
 				t.Fatal(err.Error())
 			}
 
-			found_category, err := category_service.Find(input_created.Name)
-			if err != nil {
+			var found_category types.Category
+			if err := category_service.Find(input_created.Name, &found_category); err != nil {
 				t.Fatal(err)
 			}
 			if !reflect.DeepEqual(found_category, input_created) {

--- a/src/tests/product_service_test.go
+++ b/src/tests/product_service_test.go
@@ -22,74 +22,65 @@ func TestProductService(t *testing.T) {
 				TotalReviews: 124,
 				Category: "test category 1",
 			}
+			var product types.Product
 
 			cp_input := input
 			cp_input.ProductKey = ""
-			product, err := product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("product_key should be required")
 			}
 
 			cp_input = input
 			cp_input.Title = ""
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("title should be required")
 			}
 
 			cp_input = input
 			cp_input.OriginalUrl = ""
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product);err == nil {
 				t.Fatalf("original_url should be required")
 			}
 
 			cp_input = input
 			cp_input.Rating = 0
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("rating should be required")
 			}
 
 			cp_input = input
 			cp_input.Rating = -4
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("rating cannot be negative")
 			}
 
 			cp_input = input
 			cp_input.Rating = 5.1
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("rating cannot be greater than 5")
 			}
 
 			cp_input = input
 			cp_input.Price = 0
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("price should be required")
 			}
 
 			cp_input = input
 			cp_input.Price = -100.1
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("price cannot be negative")
 			}
 
 			cp_input = input
 			cp_input.TotalReviews = 0
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("total_reviews should be required")
 			}
 
 			cp_input = input
 			cp_input.Category = ""
-			product, err = product_service.Create(&cp_input)
-			if err == nil || product != nil {
+			if err := product_service.Create(&cp_input, &product); err == nil {
 				t.Fatalf("category should be required")
 			}
 		})
@@ -104,8 +95,8 @@ func TestProductService(t *testing.T) {
 				TotalReviews: 124,
 				Category: "any",
 			}
-			product, err := product_service.Create(&input)
-			if err != nil {
+			var product types.Product
+			if err := product_service.Create(&input, &product); err != nil {
 				t.Fatal(err)
 			}
 
@@ -117,8 +108,8 @@ func TestProductService(t *testing.T) {
 			input2.Title = "Product 2"
 			input2.ProductKey = "token2"
 			input2.Price = 1.50
-			product2, err := product_service.Create(&input2)
-			if err != nil {
+			var product2 types.Product
+			if err := product_service.Create(&input2, &product2); err != nil {
 				t.Fatal(err)
 			}
 
@@ -133,8 +124,8 @@ func TestProductService(t *testing.T) {
 				input.OriginalUrl = "https://www.amazon.com/gp/product/B07G5MSF3G/ref=ppx_yo_dt_b_search_asin_image?ie=UTF8&psc=1"
 				input.ProductKey = "x"
 				input.Price = 19.99
-				product, err := product_service.Create(&input)
-				if err != nil {
+				var product types.Product
+				if err := product_service.Create(&input, &product); err != nil {
 					t.Fatal(err)
 				}
 
@@ -149,7 +140,8 @@ func TestProductService(t *testing.T) {
 				input.Category = "test"
 				input.OriginalUrl = "invalid url"
 				input.ProductKey = "y"
-				if _, err := product_service.Create(&input); err == nil {
+				var product types.Product
+				if err := product_service.Create(&input, &product); err == nil {
 					t.Fatal("should not parse invalid url: " + input.OriginalUrl)
 				}
 			})
@@ -157,7 +149,8 @@ func TestProductService(t *testing.T) {
 			t.Run("should not create with duplicate product key", func(t *testing.T) {
 				input := input
 				input.Title = "Different Product"
-				if _, err := product_service.Create(&input); err == nil {
+				var product types.Product
+				if err := product_service.Create(&input, &product); err == nil {
 					t.Fatal("should not create product with a duplicate product_key")
 				}
 			})
@@ -168,8 +161,8 @@ func TestProductService(t *testing.T) {
 		var new_product types.Product
 
 		t.Run("find by product_key", func(t *testing.T) {
-			product, err := product_service.Find("token")
-			if err != nil || product == nil {
+			var product types.Product
+			if err := product_service.Find("token", &product); err != nil {
 				t.Fatal(err, product)
 			}
 
@@ -186,31 +179,33 @@ func TestProductService(t *testing.T) {
 				TotalReviews: 4,
 				Category: "New Category",
 			}
-			product, create_err := product_service.Create(&input)
-			if create_err != nil {
-				t.Fatal(create_err)
+			
+			product = types.Product{}
+			if err := product_service.Create(&input, &product); err != nil {
+				t.Fatal(err, product)
 			}
-			found_product, found_err := product_service.Find(product.ProductKey)
+			var found_product types.Product
+			found_err := product_service.Find(input.ProductKey, &found_product)
 			if found_err != nil || !reflect.DeepEqual(found_product, product) {
 				t.Fatal(found_err, product, found_product)
 			}
-			new_product = *product
+			new_product = product
 
-			if _, err = product_service.Find("some random token that doesn't exist"); err == nil {
+			if err := product_service.Find("some random token that doesn't exist", &types.Product{}); err == nil {
 				t.Fatal("product with key doesn't exist")
 			}
 		})
 
 		t.Run("find by id", func(t *testing.T) {
-			product, err := product_service.Find(new_product.ID.String())
-			if err != nil {
+			var product types.Product
+			if err := product_service.Find(new_product.ID.String(), &product); err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(*product, new_product) {
+			if !reflect.DeepEqual(product, new_product) {
 				t.Fatal(product, new_product)
 			}
 
-			if _, err = product_service.Find(uuid.NewString()); err == nil {
+			if err := product_service.Find(uuid.NewString(), &types.Product{}); err == nil {
 				t.Fatal("product with key doesn't exist")
 			}
 		})
@@ -226,7 +221,8 @@ func TestProductService(t *testing.T) {
 			TotalReviews: 4,
 			Category: "New Category",
 		}
-		product, created, err := product_service.CreateOrUpdate(&input)
+		var product types.Product
+		created, err := product_service.CreateOrUpdate(&input, &product)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -241,7 +237,8 @@ func TestProductService(t *testing.T) {
 		input2 := input
 		input2.ProductKey = "my_new_key_input2"
 		input2.Price = 50
-		product2, created2, err2 := product_service.CreateOrUpdate(&input2)
+		var product2 types.Product
+		created2, err2 := product_service.CreateOrUpdate(&input2, &product2)
 		if err2 != nil {
 			t.Fatal(err)
 		}
@@ -318,12 +315,12 @@ func TestProductService(t *testing.T) {
 			}
 			{
 				product := (*products2)[0]
-				found_product, err := product_service.Find(product.ProductKey)
-				if err != nil {
+				var found_product types.Product
+				if err := product_service.Find(product.ProductKey, &found_product); err != nil {
 					t.Fatal("product with key not found", product.ProductKey)
 				}
-				if !reflect.DeepEqual(product, *found_product) {
-					t.Fatal(product, *found_product)
+				if !reflect.DeepEqual(product, found_product) {
+					t.Fatal(product, found_product)
 				}
 				if !(product.Price >= min || product.Price <= max) {
 					t.Fatal("price does not match")

--- a/src/tests/user_service_test.go
+++ b/src/tests/user_service_test.go
@@ -17,7 +17,7 @@ func TestUserService(t *testing.T) {
 		ImageUrl: "https://images.com/john_doe",
 	}
 
-	test_user2 := &types.CreateUser{
+	test_user2 := types.CreateUser{
 		Name: "Test User",
 		Email: "testuser@email.com",
 		ImageUrl: "https://images.com/test_user2",
@@ -25,7 +25,8 @@ func TestUserService(t *testing.T) {
 
 	t.Run("create user", func(t *testing.T) {
 		t.Run("should create user", func(t *testing.T) {
-			new_user, err := user_service.Create(&test_user1)
+			var new_user types.User
+			err := user_service.Create(&test_user1, &new_user)
 
 			if err != nil {
 				t.Fatal("should not return an error", new_user, test_user1)
@@ -37,7 +38,8 @@ func TestUserService(t *testing.T) {
 		})
 
 		t.Run("should not create existing user", func(t *testing.T) {
-			if _, err := user_service.Create(&test_user1); err == nil {
+			var user types.User
+			if err := user_service.Create(&test_user1, &user); err == nil {
 				t.Fatalf("should not create a new user")
 			}
 		})
@@ -45,7 +47,8 @@ func TestUserService(t *testing.T) {
 
 	t.Run("find user", func(t *testing.T) {
 		t.Run("should find by email", func(t *testing.T) {
-			user_by_email, err := user_service.FindByEmail(test_user1.Email)
+			var user_by_email types.User
+			err := user_service.FindByEmail(test_user1.Email, &user_by_email)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -53,34 +56,35 @@ func TestUserService(t *testing.T) {
 				t.FailNow()
 			}
 
-			if _, err = user_service.FindByEmail(user_by_email.ID.String()); err == nil {
+			if err = user_service.FindByEmail(user_by_email.ID.String(), &user_by_email); err == nil {
 				t.Fatal(err)
 			}
 		})
 
 		t.Run("should find by id", func(t *testing.T) {
-			user_by_email, err := user_service.FindByEmail(test_user1.Email)
-			if err != nil {
+			var user_by_email types.User
+			if err := user_service.FindByEmail(test_user1.Email, &user_by_email); err != nil {
 				t.Fatal(err)
 			}
-			user_by_id, err := user_service.FindById(user_by_email.ID.String())
-			if err != nil {
+			var user_by_id types.User
+			if err := user_service.FindById(user_by_email.ID.String(), &user_by_id); err != nil {
 				t.Fatal(err)
 			}
 			if user_by_id.Email != test_user1.Email || user_by_id.Name != test_user1.Name || user_by_id.ID == uuid.Nil {
 				t.FailNow()
 			}
 
-			if _, err = user_service.FindById(user_by_id.Email); err == nil {
+			if err := user_service.FindById(user_by_id.Email, &user_by_id); err == nil {
 				t.Fatal(err)
 			}
-			if _, err = user_service.FindById("some random text that is not a uuid"); err == nil {
+			if err := user_service.FindById("some random text that is not a uuid", &user_by_id); err == nil {
 				t.Fatal(err)
 			}
 		})
 
 		t.Run("should find or create", func(t *testing.T) {
-			created_user, created, err := user_service.FindOrCreate(test_user2)
+			var created_user types.User
+			created, err := user_service.FindOrCreate(&test_user2, &created_user)
 			if err != nil || !created {
 				t.Fatal(err)
 			}
@@ -88,7 +92,8 @@ func TestUserService(t *testing.T) {
 				t.FailNow()
 			}
 
-			found_user, created, err := user_service.FindOrCreate(test_user2)
+			var found_user types.User
+			created, err = user_service.FindOrCreate(&test_user2, &found_user)
 			if err != nil || created {
 				t.Fatal(err)
 			}
@@ -98,44 +103,46 @@ func TestUserService(t *testing.T) {
 		})
 
 		t.Run("should find with id and email", func(t *testing.T) {	
-			if _, err := user_service.FindByIdAndEmail(uuid.NewString(), test_user1.Email); err == nil {
+			var user types.User
+			if err := user_service.FindByIdAndEmail(uuid.NewString(), test_user1.Email, &user); err == nil {
 				t.Fatal("should not find a user with an non existing or matching uuid")
 			}
 
-			user_by_email, err := user_service.FindByEmail(test_user1.Email)
-			if err != nil {
+			var user_by_email types.User
+			if err := user_service.FindByEmail(test_user1.Email, &user_by_email); err != nil {
 				t.Fatal(err)
 			}
-
-			user, err := user_service.FindByIdAndEmail(user_by_email.ID.String(), test_user1.Email)
+ 
+			err := user_service.FindByIdAndEmail(user_by_email.ID.String(), test_user1.Email, &user)
 			if err != nil || user.ID != user_by_email.ID || user.Email != user_by_email.Email {
 				t.Fatal(err, user, user_by_email)
 			}
 			
-			if _, err = user_service.FindByIdAndEmail(user.ID.String(), test_user2.Email); err == nil {
+			if err := user_service.FindByIdAndEmail(user.ID.String(), test_user2.Email, &user); err == nil {
 				t.Fatal("should not find a user with id and email from different users")
 			}
 
-			if _, err = user_service.FindByIdAndEmail("not a uuid", test_user2.Email); err == nil {
+			if err := user_service.FindByIdAndEmail("not a uuid", test_user2.Email, &user); err == nil {
 				t.Fatal(err)
 			}
 		})
 
 		t.Run("should find by id or email", func(t *testing.T) {
-			if _, err := user_service.FindByIdOrEmail("not a uuid", test_user1.Email); err == nil {
+			var user types.User
+			if err := user_service.FindByIdOrEmail("not a uuid", test_user1.Email, &user); err == nil {
 				t.Fatal(err)
 			}
 
-			user1, err := user_service.FindByIdOrEmail(uuid.NewString(), test_user1.Email)
-			if err != nil {
+			var user1 types.User
+			if err := user_service.FindByIdOrEmail(uuid.NewString(), test_user1.Email, &user1); err != nil {
 				t.Fatal(err)
 			}
 			if user1.Email != test_user1.Email {
 				t.Fatal("email does not match", user1, test_user1)
 			}
 
-			user2, err := user_service.FindByIdOrEmail(user1.ID.String(), "not an email")
-			if err != nil {
+			var user2 types.User
+			if err := user_service.FindByIdOrEmail(user1.ID.String(), "not an email", &user2); err != nil {
 				t.Fatal(err)
 			}
 			if user2.Email != test_user1.Email {


### PR DESCRIPTION
At the moment services and other methods/functions return pointers to structs which causes many heap allocations, which will result in unnecessary GC (garbage collector) runs. To avoid this we will avoid returning pointers as much as possible by making service methods take a pointer that will hold the result this will make sure that nothing gets returned when the functions/method returns making 0 heap allocations.

https://medium.com/eureka-engineering/understanding-allocations-in-go-stack-heap-memory-9a2631b5035d 