### PR TITLE
perf: replace preload with joins

### DIFF
--- a/src/services/category_service.go
+++ b/src/services/category_service.go
@@ -25,7 +25,7 @@ func (service *CategoryService) Create(input *types.CreateCategory, output *type
 func (service *CategoryService) Find(name string, output *types.Category) error {
 	return service.DB.
 		Table(service.TABLE).
-		Where("name = ?", name).
+		Where("categories.name = ?", name).
 		First(output).
 		Error
 }

--- a/src/services/event_service.go
+++ b/src/services/event_service.go
@@ -123,7 +123,7 @@ func (service *EventService) FindAllForUser(user *types.User, output *[]types.Ev
 		Table(service.TABLE).
 		Joins("CreatedBy").
 		Joins("ModifiedBy").
-		Where("created_by_id = ?", user_id).
+		Where("events.created_by_id = ?", user_id).
 		Find(output).
 		Error
 }

--- a/src/services/product_service.go
+++ b/src/services/product_service.go
@@ -53,7 +53,7 @@ func (service *ProductService) Find(key string, output *types.Product) error {
 	id, _ := uuid.Parse(key)
 	return service.DB.
 		Table(service.TABLE).
-		Preload("Category").
+		Joins("Category").
 		Where("products.product_key = ? OR products.id = ?", key, id).
 		First(output).
 		Error
@@ -128,21 +128,21 @@ func (service *ProductService) Search(filter types.ProductFilter) (*[]types.Prod
 	
 	if filter.MinPrice > 0 || filter.MaxPrice > 0 {
 		query.
-			Where("price BETWEEN ? AND ?", filter.MinPrice, filter.MaxPrice)
+			Where("products.price BETWEEN ? AND ?", filter.MinPrice, filter.MaxPrice)
 	}
 
 	switch filter.Sort {
 	case "rating":
-		query.Order("rating DESC")
+		query.Order("products.rating DESC")
 	case "price":
-		query.Order("price DESC")
+		query.Order("products.price DESC")
 	case "totalReviews":
-		query.Order("total_reviews DESC")
+		query.Order("products.total_reviews DESC")
 	default:
-		query.Order("updated_at DESC")
+		query.Order("products.updated_at DESC")
 	}
 	err := query.
-		Preload("Category").
+		Joins("Category").
 		Find(products).
 		Error
 	return products, err

--- a/src/services/user_service.go
+++ b/src/services/user_service.go
@@ -11,7 +11,7 @@ type UserService struct {
 func (service *UserService) FindByEmail(email string, output *types.User) error {
 	return service.DB.
 		Table(service.TABLE).
-		Where("email = ?", email).
+		Where("users.email = ?", email).
 		First(output).
 		Error
 }
@@ -19,7 +19,7 @@ func (service *UserService) FindByEmail(email string, output *types.User) error 
 func (service *UserService) FindById(id string, output *types.User) error {
 	return service.DB.
 		Table(service.TABLE).
-		Where("id = ?", id).
+		Where("users.id = ?", id).
 		First(output).
 		Error
 }
@@ -27,7 +27,7 @@ func (service *UserService) FindById(id string, output *types.User) error {
 func (service *UserService) FindByIdAndEmail(id string, email string, output *types.User) error {
 	return service.DB.
 		Table(service.TABLE).
-		Where("id = ? AND email = ?", id, email).
+		Where("users.id = ? AND users.email = ?", id, email).
 		First(output).
 		Error
 }
@@ -35,7 +35,7 @@ func (service *UserService) FindByIdAndEmail(id string, email string, output *ty
 func (service *UserService) FindByIdOrEmail(id string, email string, output *types.User) error {
 	return service.DB.
 		Table(service.TABLE).
-		Where("id = ? OR email = ?", id, email).
+		Where("users.id = ? OR users.email = ?", id, email).
 		First(output).
 		Error
 }
@@ -69,7 +69,7 @@ func (service *UserService) Create(input *types.CreateUser, output *types.User) 
 func (service *UserService) DeleteById(key string) error {
 	return service.DB.
 		Table(service.TABLE).
-		Where("id = ?", key).
+		Where("users.id = ?", key).
 		Delete(&types.User{}).
 		Error
 }


### PR DESCRIPTION
We currently use `Preload` to fetch subqueries, however, this results in many issues with the database. This PR aims to replace the preload method with a simple `Join` method that essentially add an `inner join [table]` statement to the SQL query. This will ensure only **one** SQL statement to be sent to the database, instead of two (using the preload method). In addition, the preload method also creates a complicated subquery if there are multiple matches, which is not ideal since a simple join is much faster.